### PR TITLE
Bug: Fix single var config failing

### DIFF
--- a/config/cfg_lang.ml
+++ b/config/cfg_lang.ml
@@ -146,6 +146,10 @@ module Parser = struct
         (Pred { var; value = String s }, rest)
     | LPARENS :: ATOM var :: EQ :: NUMBER n :: RPARENS :: rest ->
         (Pred { var; value = Number n }, rest)
+    | ATOM var :: EQ :: STRING s :: RPARENS :: [] ->
+       (Pred { var; value = String s}, [])
+    | ATOM var :: EQ :: NUMBER n :: RPARENS :: [] ->
+        (Pred { var; value = Number n }, [])
     | ATOM var :: rest -> (Pred { var; value = String "true" }, rest)
     | _ ->
         failwith ~loc
@@ -153,7 +157,7 @@ module Parser = struct
 
   and parse_list ~loc ?(acc = []) tokens =
     match tokens with
-    | [] -> failwith ~loc "Lists can't be empty"
+    | [] -> (List.rev acc, [])
     | COMMA :: RPARENS :: rest | RPARENS :: rest -> (List.rev acc, rest)
     | COMMA :: rest | rest ->
         let pred, rest = do_parse ~loc rest in

--- a/config/cfg_lang_test.ml
+++ b/config/cfg_lang_test.ml
@@ -30,6 +30,15 @@ let () =
   test "(target_os = \"macos\")"
     [ LPARENS; ATOM "target_os"; EQ; STRING "macos"; RPARENS ];
   test "any (macos)" [ ATOM "any"; LPARENS; ATOM "macos"; RPARENS ];
+  test "all (target_os = \"macos\")"
+    [
+      ATOM "all";
+      LPARENS;
+      ATOM "target_os";
+      EQ;
+      STRING "macos";
+      RPARENS;
+    ];
   test "any ((target_os = \"macos\"))"
     [
       ATOM "any";
@@ -135,6 +144,12 @@ let () =
   test "(target = \"macos\")" (Pred { var = "target"; value = String "macos" });
   test "not((target = \"macos\"))"
     (Not (Pred { var = "target"; value = String "macos" }));
+
+  test "all(target = \"macos\")"
+    (All
+       [
+         Pred { var = "target"; value = String "macos" };
+    ]);
 
   test "all((target = \"macos\"), (what = \"nope\"))"
     (All

--- a/config/cfg_ppx.ml
+++ b/config/cfg_ppx.ml
@@ -32,7 +32,7 @@ let should_keep_module attr =
       let payload = Pprintast.string_of_structure payload in
       (* NOTE(leostera): payloads begin with `;;` *)
       let payload = String.sub payload 2 (String.length payload - 2) in
-      (* Printf.printf "\n\npayload: %S\n\n" payload; *)
+      Printf.printf "\n\npayload: %S\n\n" payload;
       if Cfg_lang.eval ~loc ~env payload then `keep else `drop
   | _ -> failwith "invalid payload"
 


### PR DESCRIPTION
This fixes the following config case that was failing before:

```
[@@config all (target_os = "macos")]
```

Added tests to validate that it's passing and all previous tests are still passing.

While it makes sense to me that `parse_list` erred on empty list, it doesn't seem to affect any valid config (at least those covered by the tests).