### PR TITLE
Fix: Remove unused 'bug' function

### DIFF
--- a/config/cfg_lang.ml
+++ b/config/cfg_lang.ml
@@ -10,16 +10,6 @@ exception Error of error
 
 let failwith ~loc error = raise (Error { loc; error = error ^ "\n" })
 
-let bug ~loc reason =
-  failwith ~loc
-    (Format.sprintf
-       {|Oops! This is a bug. We should never get here, please file an issue here \
-
-https://github.com/leostera/riot/issues/new
-
-Contenxt: %s |}
-       reason)
-
 (* let log = Printf.printf *)
 
 module Lexer = struct


### PR DESCRIPTION
Hi @leostera! I am new to the OCaml community and looking to help as I pick up the language. 

I was reading through and noticed the `bug` function seems to be unused and copied from here: 

https://github.com/riot-ml/riot/blob/9d84608b255d064ecc548677ec6d67c5d0b4367c/bytestring/bytepattern.ml#L13-L21

If this is incorrect feel free to close this PR. 