### PR TITLE
Fix: Allow the not token to be used.

### DIFF
--- a/config/cfg_lang.ml
+++ b/config/cfg_lang.ml
@@ -136,11 +136,11 @@ module Parser = struct
     | ATOM "all" :: LPARENS :: rest ->
         let list, rest = parse_list ~loc rest in
         (All list, rest)
-    | ATOM "not" :: LPARENS :: rest -> (
+    | ATOM "not" :: LPARENS :: rest | ATOM "not" :: rest -> (
         match do_parse ~loc rest with
         | pred, RPARENS :: rest -> (Not pred, rest)
-        | _ -> failwith ~loc "Not expressions must have a single parameter")
-    | ATOM ("any" | "all" | "not") :: _ ->
+        | pred, rest -> (Not pred, rest))
+    | ATOM ("any" | "all") :: _ ->
         failwith ~loc "Forms any/all/not must parenthesize its arguments"
     | LPARENS :: ATOM var :: EQ :: STRING s :: RPARENS :: rest ->
         (Pred { var; value = String s }, rest)

--- a/config/cfg_lang_test.ml
+++ b/config/cfg_lang_test.ml
@@ -133,6 +133,7 @@ let () =
 
   test "test" (Pred { var = "test"; value = String "true" });
   test "not(test)" (Not (Pred { var = "test"; value = String "true" }));
+  test "not test" (Not (Pred { var = "test"; value = String "true" }));
 
   test "(target = \"macos\")" (Pred { var = "target"; value = String "macos" });
   test "not((target = \"macos\"))"
@@ -216,6 +217,8 @@ let () =
 
   test "test" [ ("test", String "false") ] false;
   test "test" [ ("test", String "true") ] true;
+  test "not test" [ ("test", String "true") ] false;
+  test "not test" [ ("test", String "false") ] true;
   test "not(test)" [ ("test", String "true") ] false;
   test "not(test)" [ ("test", String "false") ] true;
   test "not((test=\"true\"))" [ ("test", String "false") ] true;

--- a/config/cfg_lang_test.ml
+++ b/config/cfg_lang_test.ml
@@ -137,6 +137,8 @@ let () =
   test "(target = \"macos\")" (Pred { var = "target"; value = String "macos" });
   test "not((target = \"macos\"))"
     (Not (Pred { var = "target"; value = String "macos" }));
+  test "not(target = \"macos\")"
+    (Not (Pred { var = "target"; value = String "macos" }));
 
   test "all(target = \"macos\")"
     (All [ Pred { var = "target"; value = String "macos" } ]);
@@ -216,6 +218,8 @@ let () =
   test "test" [ ("test", String "true") ] true;
   test "not(test)" [ ("test", String "true") ] false;
   test "not(test)" [ ("test", String "false") ] true;
+  test "not((test=\"true\"))" [ ("test", String "false") ] true;
+  test "not(test=\"true\")" [ ("test", String "false") ] true;
   test "(name = \"rush\")" [ ("name", String "rush") ] true;
   test "(album = 2112)" [ ("album", Number 2112) ] true;
   test "any((album = 2113), (name =\"rush\"))" [ ("album", Number 2113) ] true;

--- a/config/ppx.t/cond_type_var_constructor.ml
+++ b/config/ppx.t/cond_type_var_constructor.ml
@@ -2,6 +2,9 @@ type band =
   | Rush
   | Yes
   | KingCrimson [@config (made_up = true)]
+  | TheXX [@config (not (value = "1"))]
+  | TheWho [@config (not (the_who))]
+  | Beatles [@config (not (value = true))]
 
 (* this pattern matching is exhaustive because the config removes the
    KingCrimson constructor *)
@@ -9,6 +12,8 @@ let best_band_in_the_world x =
   match x with
   | Rush -> true
   | Yes -> false
+  | Beatles -> false
+  | TheWho -> false
 
 type band_polyvar = [
   | `Rush

--- a/config/ppx.t/run.t
+++ b/config/ppx.t/run.t
@@ -118,18 +118,18 @@
   let () = Printf.printf "sys=%s" Sys.name
 
   $ dune clean
-  $ dune exec ./main.exe
+  $ value=1 dune exec ./main.exe
   sys=unix
 
   $ dune clean
-  $ target_os=windows target_arch=x86 dune exec ./main.exe
+  $ value=1 target_os=windows target_arch=x86 dune exec ./main.exe
   sys=win32
 
   $ dune clean
-  $ dune build
+  $ value=1 dune build
 
   $ dune clean
-  $ target_os=madeup dune describe pp whole_mod.ml
+  $ value=1 target_os=madeup dune describe pp whole_mod.ml
   [@@@ocaml.ppx.context
     {
       tool_name = "ppx_driver";


### PR DESCRIPTION
Attempt to address https://github.com/ocaml-sys/config.ml/issues/2

This PR addresses the fact that the string value presented to the `eval` function strips out parenthesis in the `not` operator:

This means the following get evaluated:
`[@config (not((made_up = true)))]` -> `not (made_up = true)`
`[@config (not((made_up)))]` -> `not made_up`

