### PR TITLE
Fix: Make the equals operator work as expected.

### DIFF
--- a/config/cfg_lang.ml
+++ b/config/cfg_lang.ml
@@ -148,6 +148,8 @@ module Parser = struct
         (Pred { var; value = Number n }, rest)
     | [ ATOM var; EQ; STRING s; RPARENS ] -> (Pred { var; value = String s }, [])
     | [ ATOM var; EQ; NUMBER n; RPARENS ] -> (Pred { var; value = Number n }, [])
+    | [ ATOM var; EQ; STRING s ] -> (Pred { var; value = String s }, [])
+    | [ ATOM var; EQ; NUMBER n ] -> (Pred { var; value = Number n }, [])
     | ATOM var :: rest -> (Pred { var; value = String "true" }, rest)
     | _ ->
         failwith ~loc

--- a/config/cfg_lang_test.ml
+++ b/config/cfg_lang_test.ml
@@ -27,6 +27,7 @@ let () =
   test "" [];
   test "not" [ ATOM "not" ];
   test "not any" [ ATOM "not"; ATOM "any" ];
+  test "target_os = \"macos\"" [ ATOM "target_os"; EQ; STRING "macos" ];
   test "(target_os = \"macos\")"
     [ LPARENS; ATOM "target_os"; EQ; STRING "macos"; RPARENS ];
   test "any (macos)" [ ATOM "any"; LPARENS; ATOM "macos"; RPARENS ];
@@ -133,7 +134,7 @@ let () =
 
   test "test" (Pred { var = "test"; value = String "true" });
   test "not(test)" (Not (Pred { var = "test"; value = String "true" }));
-
+  test "target = \"macos\"" (Pred { var = "target"; value = String "macos" });
   test "(target = \"macos\")" (Pred { var = "target"; value = String "macos" });
   test "not((target = \"macos\"))"
     (Not (Pred { var = "target"; value = String "macos" }));
@@ -216,6 +217,8 @@ let () =
   test "test" [ ("test", String "true") ] true;
   test "not(test)" [ ("test", String "true") ] false;
   test "not(test)" [ ("test", String "false") ] true;
+  test "name = \"rush\"" [ ("name", String "rush") ] true;
+  test "name = \"rush\"" [ ("name", String "mush") ] false;
   test "(name = \"rush\")" [ ("name", String "rush") ] true;
   test "(album = 2112)" [ ("album", Number 2112) ] true;
   test "any((album = 2113), (name =\"rush\"))" [ ("album", Number 2113) ] true;

--- a/config/ppx.t/main.ml
+++ b/config/ppx.t/main.ml
@@ -52,5 +52,5 @@ module Sys = Sys_win32
 module Sys = Sys_win64
 [@@config all (target_os = "windows", target_arch = "arm")]
 
-let () = Printf.printf "sys=%s" Sys.name
+let () = Printf.printf "sys=%s env=%s" Sys.name Env.name
 (* will print "sys=unix" on my mac! *)

--- a/config/ppx.t/run.t
+++ b/config/ppx.t/run.t
@@ -32,13 +32,14 @@
   module Cond_recmod = Cond_recmod
   module Cond_class = Cond_class
   module Whole_mod = Whole_mod
+  module Env = struct let name = "unknown" end[@@config target_env = ""]
   module Sys = Sys_unix[@@config
                          any
                            ((target_os = "macos"), (target_os = "ios"),
                              (target_os = "watchos"), (target_os = "tvos"),
                              (target_os = "freebsd"), (target_os = "netbsd"),
                              (target_os = "linux"))]
-  let () = Printf.printf "sys=%s" Sys.name
+  let () = Printf.printf "sys=%s env=%s" Sys.name Env.name
   $ dune clean
   $ target_os=windows target_arch=x86 dune describe pp main.ml
   [@@@ocaml.ppx.context
@@ -74,9 +75,10 @@
   module Cond_recmod = Cond_recmod
   module Cond_class = Cond_class
   module Whole_mod = Whole_mod
+  module Env = struct let name = "unknown" end[@@config target_env = ""]
   module Sys = Sys_win32[@@config
                           all ((target_os = "windows"), (target_arch = "x86"))]
-  let () = Printf.printf "sys=%s" Sys.name
+  let () = Printf.printf "sys=%s env=%s" Sys.name Env.name
 
   $ dune clean
   $ target_os=windows target_arch=arm dune describe pp main.ml
@@ -113,17 +115,18 @@
   module Cond_recmod = Cond_recmod
   module Cond_class = Cond_class
   module Whole_mod = Whole_mod
+  module Env = struct let name = "unknown" end[@@config target_env = ""]
   module Sys = Sys_win64[@@config
                           all ((target_os = "windows"), (target_arch = "arm"))]
-  let () = Printf.printf "sys=%s" Sys.name
+  let () = Printf.printf "sys=%s env=%s" Sys.name Env.name
 
   $ dune clean
   $ dune exec ./main.exe
-  sys=unix
+  sys=unix env=unknown
 
   $ dune clean
   $ target_os=windows target_arch=x86 dune exec ./main.exe
-  sys=win32
+  sys=win32 env=unknown
 
   $ dune clean
   $ dune build
@@ -147,3 +150,4 @@
       unsafe_string = false;
       cookies = []
     }]
+  external foo : unit -> int = "made_up_call"


### PR DESCRIPTION
While working on a separate feature I realized the variable check wasn't working as expected. 

The issue is that `[@@config target_env = ""]` evaluates to a payload of `target = ""` and this isn't a case we match on. It was working but not as intended because it was only looking at the variable and not doing the comparison. 

For example the test case in `run.t` below should include the function `foo` during compile since the variable `target_os` is explicitly set to `"madeup"` but that wasn't happening. 
```ocaml
$ target_os=madeup dune describe pp whole_mod.ml
```

```ocaml
[@@@config target_os = "madeup"]

external foo : unit -> int = "made_up_call"
```

Now it is happening [here](https://github.com/ocaml-sys/config.ml/compare/main...KFoxder:config.ml:fix_variable_check?expand=1#diff-3514da5756b715d8a14b246fb6c618c10b6d2d2dd4aa217d8f0246d1cd61d4a1R153) in the test as expected.