### PR TITLE
Tidy up eval_attr by extracting the expression

### DIFF
--- a/config/cfg_ppx.ml
+++ b/config/cfg_ppx.ml
@@ -33,12 +33,9 @@ let eval_attr attr =
     let loc = attr.attr_loc in
     (* Printf.printf "\n\nattr name: %S\n\n" attr.attr_name.txt; *)
     match attr.attr_payload with
-    | PStr payload ->
-        let payload = Pprintast.string_of_structure payload in
-        (* NOTE(leostera): payloads begin with `;;` *)
-        let payload = String.sub payload 2 (String.length payload - 2) in
-        (* Printf.printf "\n\npayload: %S\n\n" payload; *)
-        if Cfg_lang.eval ~loc ~env payload then `keep else `drop
+    | PStr [ { pstr_desc = Pstr_eval (e, []); _ } ] ->
+        let e = Pprintast.string_of_expression e in
+        if Cfg_lang.eval ~loc ~env e then `keep else `drop
     | _ -> `keep
 
 let rec should_keep attrs =

--- a/config/cfg_ppx.ml
+++ b/config/cfg_ppx.ml
@@ -35,6 +35,7 @@ let eval_attr attr =
     match attr.attr_payload with
     | PStr [ { pstr_desc = Pstr_eval (e, []); _ } ] ->
         let e = Pprintast.string_of_expression e in
+        (* Printf.printf "\n\npayload: %S\n\n" payload; *)
         if Cfg_lang.eval ~loc ~env e then `keep else `drop
     | _ -> `keep
 


### PR DESCRIPTION
This removes the string manipulation, by relying on printing a smaller part of the code.

On the flip side we now rely on the way the attributes are encoded as a Pstr_eval in the payload, but I don't see that changing in the near future.