### PR TITLE
Inspect the expression instead of parsing its representation

### DIFF
--- a/config.opam
+++ b/config.opam
@@ -14,7 +14,6 @@ bug-reports: "https://github.com/ocaml-sys/config.ml/issues"
 depends: [
   "ocaml" {>= "5.1"}
   "ppxlib" {>= "0.31.0"}
-  "sedlex" {>= "3.2"}
   "spices" {>= "0.0.2"}
   "dune" {>= "3.11"}
   "odoc" {with-doc}

--- a/config/cfg_ppx.ml
+++ b/config/cfg_ppx.ml
@@ -33,12 +33,9 @@ let eval_attr attr =
     let loc = attr.attr_loc in
     (* Printf.printf "\n\nattr name: %S\n\n" attr.attr_name.txt; *)
     match attr.attr_payload with
-    | PStr payload ->
-        let payload = Pprintast.string_of_structure payload in
-        (* NOTE(leostera): payloads begin with `;;` *)
-        let payload = String.sub payload 2 (String.length payload - 2) in
-        (* Printf.printf "\n\npayload: %S\n\n" payload; *)
-        if Cfg_lang.eval ~loc ~env payload then `keep else `drop
+    | PStr [ { pstr_desc = Pstr_eval (e, []); _ } ] ->
+        let e = Pprintast.string_of_expression e in
+        if Cfg_lang.eval ~loc ~env e then `keep else `drop
     | _ -> `keep
 
 let rec should_keep attrs =

--- a/config/cfg_ppx.ml
+++ b/config/cfg_ppx.ml
@@ -34,7 +34,6 @@ let eval_attr attr =
     (* Printf.printf "\n\nattr name: %S\n\n" attr.attr_name.txt; *)
     match attr.attr_payload with
     | PStr [ { pstr_desc = Pstr_eval (e, []); _ } ] ->
-        let e = Pprintast.string_of_expression e in
         if Cfg_lang.eval ~loc ~env e then `keep else `drop
     | _ -> `keep
 

--- a/config/cfg_ppx.ml
+++ b/config/cfg_ppx.ml
@@ -34,6 +34,8 @@ let eval_attr attr =
     (* Printf.printf "\n\nattr name: %S\n\n" attr.attr_name.txt; *)
     match attr.attr_payload with
     | PStr [ { pstr_desc = Pstr_eval (e, []); _ } ] ->
+        (* let e = Pprintast.string_of_expression e in *)
+        (* Printf.printf "\n\npayload: %S\n\n" e; *)
         if Cfg_lang.eval ~loc ~env e then `keep else `drop
     | _ -> `keep
 

--- a/config/dune
+++ b/config/dune
@@ -13,8 +13,8 @@
  (name cfg_lang)
  (modules cfg_lang)
  (preprocess
-  (pps sedlex.ppx ppxlib.metaquot))
- (libraries compiler-libs ppxlib sedlex spices))
+  (pps ppxlib.metaquot))
+ (libraries compiler-libs ppxlib spices))
 
 (test
  (package config)

--- a/config/ppx.t/main.ml
+++ b/config/ppx.t/main.ml
@@ -52,5 +52,5 @@ module Sys = Sys_win32
 module Sys = Sys_win64
 [@@config all (target_os = "windows", target_arch = "arm")]
 
-let () = Printf.printf "sys=%s" Sys.name
+let () = Printf.printf "sys=%s env=%s" Sys.name Env.name
 (* will print "sys=unix" on my mac! *)

--- a/config/ppx.t/run.t
+++ b/config/ppx.t/run.t
@@ -32,13 +32,14 @@
   module Cond_recmod = Cond_recmod
   module Cond_class = Cond_class
   module Whole_mod = Whole_mod
+  module Env = struct let name = "unknown" end[@@config target_env = ""]
   module Sys = Sys_unix[@@config
                          any
                            ((target_os = "macos"), (target_os = "ios"),
                              (target_os = "watchos"), (target_os = "tvos"),
                              (target_os = "freebsd"), (target_os = "netbsd"),
                              (target_os = "linux"))]
-  let () = Printf.printf "sys=%s" Sys.name
+  let () = Printf.printf "sys=%s env=%s" Sys.name Env.name
   $ dune clean
   $ target_os=windows target_arch=x86 dune describe pp main.ml
   [@@@ocaml.ppx.context
@@ -74,9 +75,10 @@
   module Cond_recmod = Cond_recmod
   module Cond_class = Cond_class
   module Whole_mod = Whole_mod
+  module Env = struct let name = "unknown" end[@@config target_env = ""]
   module Sys = Sys_win32[@@config
                           all ((target_os = "windows"), (target_arch = "x86"))]
-  let () = Printf.printf "sys=%s" Sys.name
+  let () = Printf.printf "sys=%s env=%s" Sys.name Env.name
 
   $ dune clean
   $ target_os=windows target_arch=arm dune describe pp main.ml
@@ -113,17 +115,18 @@
   module Cond_recmod = Cond_recmod
   module Cond_class = Cond_class
   module Whole_mod = Whole_mod
+  module Env = struct let name = "unknown" end[@@config target_env = ""]
   module Sys = Sys_win64[@@config
                           all ((target_os = "windows"), (target_arch = "arm"))]
-  let () = Printf.printf "sys=%s" Sys.name
+  let () = Printf.printf "sys=%s env=%s" Sys.name Env.name
 
   $ dune clean
   $ dune exec ./main.exe
-  sys=unix
+  sys=unix env=unknown
 
   $ dune clean
   $ target_os=windows target_arch=x86 dune exec ./main.exe
-  sys=win32
+  sys=win32 env=unknown
 
   $ dune clean
   $ dune build
@@ -147,3 +150,4 @@
       unsafe_string = false;
       cookies = []
     }]
+  external foo : unit -> int = "made_up_call"

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,6 @@
   (depends
     (ocaml (>= "5.1"))
     (ppxlib (>= 0.31.0))
-    (sedlex (>= "3.2"))
     (spices (>= "0.0.2"))
     dune)
   (tags (conditional compilation target_os target_arch arch os system)))


### PR DESCRIPTION
Based on top of #10, and also the tests fixed in #9

The idea is to re-use the expressions (already parsed by the ocaml compiler) instead of re-parsing its string representation. It works because the config language is a subset of ocaml expressions. And this allows to lift some constraints to use more of the ocaml syntax, e.g. not enforcing parentheses if there is no ambiguity.