### PR TITLE
Fix tests on main

### DIFF
--- a/config/ppx.t/run.t
+++ b/config/ppx.t/run.t
@@ -1,4 +1,4 @@
-  $ target_os=macos dune describe pp main.ml
+  $ target_os=macos target_env="" dune describe pp main.ml
   [@@@ocaml.ppx.context
     {
       tool_name = "ppx_driver";
@@ -40,8 +40,9 @@
                              (target_os = "freebsd"), (target_os = "netbsd"),
                              (target_os = "linux"))]
   let () = Printf.printf "sys=%s env=%s" Sys.name Env.name
+
   $ dune clean
-  $ target_os=windows target_arch=x86 dune describe pp main.ml
+  $ target_os=windows target_arch=x86 target_env="" dune describe pp main.ml
   [@@@ocaml.ppx.context
     {
       tool_name = "ppx_driver";
@@ -81,7 +82,7 @@
   let () = Printf.printf "sys=%s env=%s" Sys.name Env.name
 
   $ dune clean
-  $ target_os=windows target_arch=arm dune describe pp main.ml
+  $ target_os=windows target_arch=arm target_env="" dune describe pp main.ml
   [@@@ocaml.ppx.context
     {
       tool_name = "ppx_driver";
@@ -121,11 +122,7 @@
   let () = Printf.printf "sys=%s env=%s" Sys.name Env.name
 
   $ dune clean
-  $ dune exec ./main.exe
-  sys=unix env=unknown
-
-  $ dune clean
-  $ target_os=windows target_arch=x86 dune exec ./main.exe
+  $ target_os=windows target_arch=x86 target_env="" dune exec ./main.exe
   sys=win32 env=unknown
 
   $ dune clean

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,4 @@
 (lang dune 3.11)
-(using mdx 0.4)
 
 (name config)
 


### PR DESCRIPTION
Now that we are printing the `target_env` from this PR: #11 the tests have been breaking on `ubuntu` since it seems we all are using `macos` locally for development. In order to fix the tests I am specficing the `target_env` explicitly. This does defeat __some__ of the purpose of running the test suite on `ubuntu` but I couldn't figure out a good way to conditionally run `cram` tests since regex is no longer supported (see [docs](https://dune.readthedocs.io/en/stable/tests.html#cram-tests:~:text=Note%3A%20Unlike%20Dune%E2%80%99s,introduce%20output%20matchers.)). 

If there is a better or preferred way, happy to make changes. Failing tests were bothering me :) 