### PR TITLE
Fix Tests: Install ocamlformat in GHA for fmt command.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,9 @@ jobs:
 
       - run: opam install . --deps-only --with-test
 
+      # Needed for dune fmt
+      - run: opam install ocamlformat=0.26.1
+
       - run: opam exec -- dune fmt
 
       - run: opam exec -- dune build

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,2 @@
+profile = default
+version = 0.26.1


### PR DESCRIPTION
1. Install `ocamlformat` so the GitHub Actions run successfully. 
2. Add explicit format type and version